### PR TITLE
Add forcing field to SwanConfig for constant WIND/ICE inputs

### DIFF
--- a/docs/api-reference/config.md
+++ b/docs/api-reference/config.md
@@ -10,6 +10,7 @@ The `SwanConfig` class is the main entry point for configuring SWAN simulations.
         - cgrid
         - startup
         - inpgrid
+        - forcing
         - boundary
         - initial
         - physics

--- a/docs/components/group.md
+++ b/docs/components/group.md
@@ -4,6 +4,7 @@ SWAN group commands
 
 ::: rompy_swan.components.group.BaseGroupComponent
 ::: rompy_swan.components.group.STARTUP
+::: rompy_swan.components.group.FORCING
 ::: rompy_swan.components.group.INPGRIDS
 ::: rompy_swan.components.group.PHYSICS
 ::: rompy_swan.components.group.OUTPUT

--- a/docs/components/inpgrid.md
+++ b/docs/components/inpgrid.md
@@ -18,5 +18,8 @@ Input grids (INPGRID) define the spatial grids for external forcing data such as
 
 ## Specialized Grids
 
+!!! warning "Deprecation notice"
+    `WIND` and `ICE` inside `INPGRIDS` (i.e. as entries in `inpgrid`) are deprecated. For constant, spatially-uniform wind or ice forcing use [`SwanConfig.forcing`](../user-guide/configuration.md#forcing) with the [`FORCING`](group.md) group component instead. Gridded, time-varying wind/ice should be supplied via `DataInterface`.
+
 ::: rompy_swan.components.inpgrid.WIND
 ::: rompy_swan.components.inpgrid.ICE

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -137,7 +137,8 @@ physics:
 |-------|------|-------------|
 | `cgrid` | REGULAR, CURVILINEAR, UNSTRUCTURED | Computational grid (required) |
 | `startup` | STARTUP | Startup commands (PROJECT, SET, MODE, etc.) |
-| `inpgrid` | INPGRIDS, DataInterface | Input grids for bathymetry, wind, etc. |
+| `inpgrid` | INPGRIDS, DataInterface | Input grids for bathymetry, wind, currents, etc. |
+| `forcing` | FORCING | Constant (non-gridded) wind and/or ice forcing |
 | `boundary` | BOUNDSPEC, BOUNDNEST1-3, BoundaryInterface | Boundary conditions |
 | `initial` | INITIAL | Initial conditions |
 | `physics` | PHYSICS | Physics commands |
@@ -179,6 +180,44 @@ physics = PHYSICS(
     triad=True,  # Enable with defaults
 )
 ```
+
+### FORCING
+
+Prescribes constant (spatially uniform) wind and/or sea-ice forcing. Use this when you want to specify a single wind speed/direction or an ice fraction without providing a gridded file.
+
+```python
+from rompy_swan.components.group import FORCING
+from rompy_swan.components.inpgrid import WIND, ICE
+
+# Constant wind only
+forcing = FORCING(wind=WIND(vel=10.0, dir=270.0))
+
+# Constant ice only
+forcing = FORCING(ice=ICE(aice=0.5, hice=1.5))
+
+# Both wind and ice
+forcing = FORCING(
+    wind=WIND(vel=10.0, dir=270.0),
+    ice=ICE(aice=0.5, hice=1.5),
+)
+```
+
+YAML equivalent:
+
+```yaml
+forcing:
+  wind:
+    vel: 10.0
+    dir: 270.0
+  ice:
+    aice: 0.5
+    hice: 1.5
+```
+
+At least one of `wind` or `ice` must be supplied; specifying neither raises a `ValidationError`.
+
+!!! note
+    `FORCING` is for constant, uniform inputs. For time-varying or spatially varying wind/ice, use `inpgrid` with a `DataInterface` source instead.
 
 ### INPGRIDS
 

--- a/src/rompy_swan/components/group.py
+++ b/src/rompy_swan/components/group.py
@@ -168,6 +168,59 @@ class STARTUP(BaseGroupComponent):
 
 
 # =====================================================================================
+# Forcing
+# =====================================================================================
+class FORCING(BaseGroupComponent):
+    """SWAN constant forcing group component.
+
+    .. code-block:: text
+
+        WIND vel dir [cc]
+        ICE aice [hice]
+
+    This group component holds constant (non-gridded) forcing inputs. At most one
+    WIND and one ICE instance may be provided; use the INPGRID-based components for
+    spatially-varying inputs.
+
+    Examples
+    --------
+
+    .. ipython:: python
+        :okwarning:
+
+        from rompy_swan.components.group import FORCING
+        forcing = FORCING(wind=dict(vel=10.0, dir=270.0))
+        print(forcing.render())
+        forcing = FORCING(
+            wind=dict(vel=10.0, dir=270.0),
+            ice=dict(aice=0.5, hice=1.5),
+        )
+        print(forcing.render())
+
+    """
+
+    model_type: Literal["forcing", "FORCING"] = Field(
+        default="forcing", description="Model type discriminator"
+    )
+    wind: Optional[WIND] = Field(default=None, description="Constant wind forcing")
+    ice: Optional[ICE] = Field(default=None, description="Constant ice forcing")
+
+    @model_validator(mode="after")
+    def at_least_one(self) -> "FORCING":
+        if self.wind is None and self.ice is None:
+            raise ValueError("At least one of wind or ice must be specified")
+        return self
+
+    def cmd(self) -> str | list:
+        parts = []
+        if self.wind is not None:
+            parts.append(self.wind.cmd())
+        if self.ice is not None:
+            parts.append(self.ice.cmd())
+        return parts
+
+
+# =====================================================================================
 # Inpgrid
 # =====================================================================================
 INPGRID_TYPE = Annotated[

--- a/src/rompy_swan/components/group.py
+++ b/src/rompy_swan/components/group.py
@@ -8,7 +8,7 @@ import logging
 import warnings
 from typing import Annotated, Literal, Optional, Union
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, SerializeAsAny, field_validator, model_validator
 
 from rompy_swan.components.base import BaseComponent
 from rompy_swan.components.inpgrid import CURVILINEAR, ICE, REGULAR, UNSTRUCTURED, WIND
@@ -239,7 +239,7 @@ class INPGRIDS(BaseGroupComponent):
     model_type: Literal["inpgrids"] = Field(
         default="inpgrids", description="Model type discriminator"
     )
-    inpgrids: list[INPGRID_TYPE] = Field(
+    inpgrids: list[SerializeAsAny[INPGRID_TYPE]] = Field(
         min_length=1,
         description="List of input grid components",
     )

--- a/src/rompy_swan/components/group.py
+++ b/src/rompy_swan/components/group.py
@@ -5,6 +5,7 @@ This module provides group components for organizing SWAN model configurations i
 """
 
 import logging
+import warnings
 from typing import Annotated, Literal, Optional, Union
 
 from pydantic import Field, field_validator, model_validator
@@ -250,6 +251,15 @@ class INPGRIDS(BaseGroupComponent):
         grid_types = [inp.grid_type for inp in inpgrids if hasattr(inp, "grid_type")]
         if len(grid_types) != len(set(grid_types)):
             raise ValueError("Each grid type must be unique")
+        constant_types = [inp for inp in inpgrids if isinstance(inp, (WIND, ICE))]
+        if constant_types:
+            names = ", ".join(type(c).__name__ for c in constant_types)
+            warnings.warn(
+                f"Specifying {names} inside INPGRIDS is deprecated. Use the "
+                "`SwanConfig.forcing` field instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return inpgrids
 
     def cmd(self) -> str | list:

--- a/src/rompy_swan/config.py
+++ b/src/rompy_swan/config.py
@@ -9,7 +9,7 @@ import warnings
 from pathlib import Path
 from typing import Annotated, Literal, Optional, Union
 
-from pydantic import Field, model_validator
+from pydantic import Field, SerializeAsAny, model_validator
 
 from rompy.core.config import BaseConfig
 from rompy.formatting import get_formatted_header_footer
@@ -45,11 +45,11 @@ CGRID_TYPES = Annotated[
     Field(description="Cgrid component", discriminator="model_type"),
 ]
 INPGRID_TYPES = Annotated[
-    Union[INPGRIDS, DataInterface],
+    SerializeAsAny[Union[INPGRIDS, DataInterface]],
     Field(description="Input grid components", discriminator="model_type"),
 ]
 FORCING_TYPE = Annotated[
-    Union[WIND, ICE],
+    SerializeAsAny[Union[WIND, ICE]],
     Field(description="Constant forcing input component", discriminator="model_type"),
 ]
 BOUNDARY_TYPES = Annotated[

--- a/src/rompy_swan/config.py
+++ b/src/rompy_swan/config.py
@@ -15,8 +15,7 @@ from rompy.core.config import BaseConfig
 from rompy.formatting import get_formatted_header_footer
 from rompy.logging import get_logger
 from rompy_swan.components import boundary, cgrid, numerics
-from rompy_swan.components.group import INPGRIDS, LOCKUP, OUTPUT, PHYSICS, STARTUP
-from rompy_swan.components.inpgrid import ICE, WIND
+from rompy_swan.components.group import FORCING, INPGRIDS, LOCKUP, OUTPUT, PHYSICS, STARTUP
 from rompy_swan.grid import SwanGrid
 from rompy_swan.interface import (
     BoundaryInterface,
@@ -47,10 +46,6 @@ CGRID_TYPES = Annotated[
 INPGRID_TYPES = Annotated[
     SerializeAsAny[Union[INPGRIDS, DataInterface]],
     Field(description="Input grid components", discriminator="model_type"),
-]
-FORCING_TYPE = Annotated[
-    SerializeAsAny[Union[WIND, ICE]],
-    Field(description="Constant forcing input component", discriminator="model_type"),
 ]
 BOUNDARY_TYPES = Annotated[
     Union[
@@ -155,7 +150,7 @@ class SwanConfig(BaseConfig):
     cgrid: CGRID_TYPES
     startup: Optional[STARTUP_TYPE] = Field(default=None)
     inpgrid: Optional[INPGRID_TYPES] = Field(default=None)
-    forcing: Optional[list[FORCING_TYPE]] = Field(default=None)
+    forcing: Optional[FORCING] = Field(default=None)
     boundary: Optional[BOUNDARY_TYPES] = Field(default=None)
     initial: Optional[INITIAL_TYPE] = Field(default=None)
     physics: Optional[PHYSICS_TYPE] = Field(default=None)
@@ -688,7 +683,7 @@ class SwanConfig(BaseConfig):
 
         if self.forcing:
             logger.debug("Rendering constant forcing configuration")
-            ret["forcing"] = "\n".join(item.render() for item in self.forcing)
+            ret["forcing"] = self.forcing.render()
 
         # inpgrid / boundary may use the Interface api so we need passing the args
         if self.inpgrid and isinstance(self.inpgrid, DataInterface):

--- a/src/rompy_swan/config.py
+++ b/src/rompy_swan/config.py
@@ -16,6 +16,7 @@ from rompy.formatting import get_formatted_header_footer
 from rompy.logging import get_logger
 from rompy_swan.components import boundary, cgrid, numerics
 from rompy_swan.components.group import INPGRIDS, LOCKUP, OUTPUT, PHYSICS, STARTUP
+from rompy_swan.components.inpgrid import ICE, WIND
 from rompy_swan.grid import SwanGrid
 from rompy_swan.interface import (
     BoundaryInterface,
@@ -46,6 +47,10 @@ CGRID_TYPES = Annotated[
 INPGRID_TYPES = Annotated[
     Union[INPGRIDS, DataInterface],
     Field(description="Input grid components", discriminator="model_type"),
+]
+FORCING_TYPE = Annotated[
+    Union[WIND, ICE],
+    Field(description="Constant forcing input component", discriminator="model_type"),
 ]
 BOUNDARY_TYPES = Annotated[
     Union[
@@ -150,6 +155,7 @@ class SwanConfig(BaseConfig):
     cgrid: CGRID_TYPES
     startup: Optional[STARTUP_TYPE] = Field(default=None)
     inpgrid: Optional[INPGRID_TYPES] = Field(default=None)
+    forcing: Optional[list[FORCING_TYPE]] = Field(default=None)
     boundary: Optional[BOUNDARY_TYPES] = Field(default=None)
     initial: Optional[INITIAL_TYPE] = Field(default=None)
     physics: Optional[PHYSICS_TYPE] = Field(default=None)
@@ -679,6 +685,10 @@ class SwanConfig(BaseConfig):
         if self.lockup:
             logger.debug("Rendering lockup configuration")
             ret["lockup"] = self.lockup.render()
+
+        if self.forcing:
+            logger.debug("Rendering constant forcing configuration")
+            ret["forcing"] = "\n".join(item.render() for item in self.forcing)
 
         # inpgrid / boundary may use the Interface api so we need passing the args
         if self.inpgrid and isinstance(self.inpgrid, DataInterface):

--- a/src/rompy_swan/config.py
+++ b/src/rompy_swan/config.py
@@ -208,6 +208,47 @@ class SwanConfig(BaseConfig):
         """Ensure bottom and water level grids are not curvilinear for RAY."""
         return self
 
+    @model_validator(mode="after")
+    def resolve_segment_ij_sentinels(self) -> "SwanConfig":
+        """Replace -1 sentinel values in BOUNDSPEC SEGMENT IJ with grid max indices.
+
+        SWAN terminates the SEGMENT IJ reading loop when it encounters a negative i
+        value, so -1 cannot be used literally. This validator allows users to specify
+        -1 as a shorthand for the last grid index (mx for i, my for j) and replaces
+        it with the actual value derived from the cgrid definition.
+        """
+        from rompy_swan.subcomponents.base import IJ
+        from rompy_swan.subcomponents.boundary import SEGMENT
+
+        if not isinstance(self.boundary, boundary.BOUNDSPEC):
+            return self
+        if not isinstance(self.boundary.location, SEGMENT):
+            return self
+        if not isinstance(self.boundary.location.points, IJ):
+            return self
+
+        points = self.boundary.location.points
+        if -1 not in points.i and -1 not in points.j:
+            return self
+
+        grid = self.cgrid.grid
+        if not hasattr(grid, "mx") or not hasattr(grid, "my"):
+            return self
+
+        new_i = [grid.mx if v == -1 else v for v in points.i]
+        new_j = [grid.my if v == -1 else v for v in points.j]
+
+        logger.info(
+            f"Resolved SEGMENT IJ sentinel -1 values to grid max indices "
+            f"(mx={grid.mx}, my={grid.my}): i={new_i}, j={new_j}"
+        )
+
+        new_points = points.model_copy(update={"i": new_i, "j": new_j})
+        new_location = self.boundary.location.model_copy(update={"points": new_points})
+        self.boundary = self.boundary.model_copy(update={"location": new_location})
+
+        return self
+
     @property
     def grid(self):
         """Define a SwanGrid from the cgrid field."""

--- a/src/rompy_swan/interface.py
+++ b/src/rompy_swan/interface.py
@@ -145,6 +145,7 @@ class OutputInterface(TimeInterface):
                 if nest.nestout is not None:
                     times = nest.nestout.times or TimeRangeOpen()
                     nest.nestout.times = self._timerange(times, nest.nestout.suffix)
+        return self
 
     def _timerange(self, times: TimeRangeOpen, suffix: str) -> TimeRangeOpen:
         """Convert generic TimeRange into the Swan TimeRangeOpen subcomponent."""
@@ -188,3 +189,4 @@ class LockupInterface(TimeInterface):
         else:
             raise ValueError(f"Unknown time type {type(times)}")
         self.group.compute.times = times
+        return self

--- a/src/rompy_swan/subcomponents/base.py
+++ b/src/rompy_swan/subcomponents/base.py
@@ -98,12 +98,25 @@ class IJ(BaseSubComponent):
 
     .. code-block:: text
 
-        < [x] [y] >
+        < [i] [j] >
+
+    Grid indices are 0-based and must be in the range ``0 ≤ i ≤ mx`` and
+    ``0 ≤ j ≤ my`` where ``mx`` and ``my`` are the number of cells in each
+    direction as defined by the CGRID command.
 
     Note
     ----
-    Coordinates should be given in m when Cartesian coordinates are used or degrees
-    when Spherical coordinates are used (see command `COORD`).
+    A value of ``-1`` may be used as a sentinel for the last grid index: ``-1``
+    in the ``i`` list is replaced by ``mx``, and ``-1`` in the ``j`` list is
+    replaced by ``my``. The substitution is performed automatically by
+    :meth:`SwanConfig.resolve_segment_ij_sentinels` when the IJ object is used
+    as the points of a BOUNDSPEC SEGMENT location.
+
+    Warning
+    -------
+    SWAN terminates its SEGMENT IJ reading loop when it encounters a negative
+    ``i`` value, so ``-1`` **cannot** be passed literally to SWAN — it must be
+    resolved to the actual grid index before the INPUT file is written.
 
     Examples
     --------

--- a/src/rompy_swan/subcomponents/readgrid.py
+++ b/src/rompy_swan/subcomponents/readgrid.py
@@ -144,7 +144,7 @@ class READGRID(BaseSubComponent, ABC):
         gt=0.0,
     )
     idla: IDLA = Field(
-        default=1,
+        default=IDLA.ONE,
         description=(
             "Prescribes the order in which the values of bottom levels "
             "and other fields should be given in the file"

--- a/src/rompy_swan/templates/swan/{{runtime.staging_dir}}/INPUT
+++ b/src/rompy_swan/templates/swan/{{runtime.staging_dir}}/INPUT
@@ -16,6 +16,8 @@
 
 {% if config.get("inpgrid") %}{{config.inpgrid}}{% endif %}
 
+{% if config.get("forcing") %}{{config.forcing}}{% endif %}
+
 
 ! Boundary and Initial conditions -------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/tests/components/test_inpgrid.py
+++ b/tests/components/test_inpgrid.py
@@ -12,10 +12,12 @@ logger = get_test_logger(__name__)
 from rompy_swan.components.group import INPGRIDS
 from rompy_swan.components.inpgrid import (
     CURVILINEAR,
+    ICE,
     INPGRID,
     READINP,
     REGULAR,
     UNSTRUCTURED,
+    WIND,
 )
 from rompy_swan.subcomponents.time import NONSTATIONARY
 from rompy_swan.types import GridOptions
@@ -153,3 +155,29 @@ def test_inpgrids_unique_var(nonstat, readinp):
 
     with pytest.raises(ValidationError):
         INPGRIDS(inpgrids=[bottom, wind])
+
+
+def test_wind_render():
+    wind = WIND(vel=10.0, dir=270.0)
+    rendered = wind.render()
+    assert "WIND" in rendered
+    assert "vel=10.0" in rendered
+    assert "dir=270.0" in rendered
+
+
+def test_ice_render():
+    ice = ICE(aice=0.5, hice=1.5)
+    rendered = ice.render()
+    assert "ICE" in rendered
+    assert "aice=0.5" in rendered
+    assert "hice=1.5" in rendered
+
+
+def test_inpgrids_wind_constant_deprecated():
+    with pytest.warns(DeprecationWarning, match="WIND.*deprecated"):
+        INPGRIDS(inpgrids=[WIND(vel=5.0, dir=180.0)])
+
+
+def test_inpgrids_ice_constant_deprecated():
+    with pytest.warns(DeprecationWarning, match="ICE.*deprecated"):
+        INPGRIDS(inpgrids=[ICE(aice=0.8, hice=2.0)])

--- a/tests/test_swan_config.py
+++ b/tests/test_swan_config.py
@@ -8,7 +8,7 @@ from test_utils.logging import get_test_logger
 logger = get_test_logger(__name__)
 
 from rompy_swan.components.cgrid import REGULAR as CGRID_REGULAR
-from rompy_swan.components.group import LOCKUP
+from rompy_swan.components.group import FORCING, LOCKUP
 from rompy_swan.components.inpgrid import ICE, WIND
 from rompy_swan.config import SwanConfig
 from rompy_swan.subcomponents.readgrid import GRIDREGULAR
@@ -38,41 +38,41 @@ def ice():
     return ICE(aice=0.5, hice=1.5)
 
 
-def test_forcing_wind(cgrid, wind):
-    config = SwanConfig(cgrid=cgrid, forcing=[wind])
-    assert len(config.forcing) == 1
-    assert isinstance(config.forcing[0], WIND)
-    assert config.forcing[0].vel == 10.0
-    assert config.forcing[0].dir == 270.0
+def test_forcing_wind_only(cgrid, wind):
+    config = SwanConfig(cgrid=cgrid, forcing=FORCING(wind=wind))
+    assert isinstance(config.forcing.wind, WIND)
+    assert config.forcing.wind.vel == 10.0
+    assert config.forcing.wind.dir == 270.0
+    assert config.forcing.ice is None
 
 
-def test_forcing_ice(cgrid, ice):
-    config = SwanConfig(cgrid=cgrid, forcing=[ice])
-    assert len(config.forcing) == 1
-    assert isinstance(config.forcing[0], ICE)
-    assert config.forcing[0].aice == 0.5
-    assert config.forcing[0].hice == 1.5
+def test_forcing_ice_only(cgrid, ice):
+    config = SwanConfig(cgrid=cgrid, forcing=FORCING(ice=ice))
+    assert isinstance(config.forcing.ice, ICE)
+    assert config.forcing.ice.aice == 0.5
+    assert config.forcing.ice.hice == 1.5
+    assert config.forcing.wind is None
 
 
-def test_forcing_multiple(cgrid, wind, ice):
-    config = SwanConfig(cgrid=cgrid, forcing=[wind, ice])
-    assert len(config.forcing) == 2
-    assert isinstance(config.forcing[0], WIND)
-    assert isinstance(config.forcing[1], ICE)
+def test_forcing_wind_and_ice(cgrid, wind, ice):
+    config = SwanConfig(cgrid=cgrid, forcing=FORCING(wind=wind, ice=ice))
+    assert isinstance(config.forcing.wind, WIND)
+    assert isinstance(config.forcing.ice, ICE)
+
+
+def test_forcing_requires_at_least_one(cgrid):
+    with pytest.raises(Exception):
+        SwanConfig(cgrid=cgrid, forcing=FORCING())
 
 
 def test_forcing_from_dict(cgrid):
     config = SwanConfig(
         cgrid=cgrid,
-        forcing=[
-            {"model_type": "wind", "vel": 15.0, "dir": 90.0},
-            {"model_type": "ice", "aice": 0.3, "hice": 1.0},
-        ],
+        forcing={"wind": {"vel": 15.0, "dir": 90.0}, "ice": {"aice": 0.3, "hice": 1.0}},
     )
-    assert len(config.forcing) == 2
-    assert isinstance(config.forcing[0], WIND)
-    assert config.forcing[0].vel == 15.0
-    assert isinstance(config.forcing[1], ICE)
+    assert isinstance(config.forcing.wind, WIND)
+    assert config.forcing.wind.vel == 15.0
+    assert isinstance(config.forcing.ice, ICE)
 
 
 def test_forcing_none_by_default(cgrid):
@@ -84,7 +84,7 @@ def test_forcing_render_in_call(cgrid, wind, lockup, tmpdir):
     """forcing items appear in the rendered INPUT file."""
     from rompy.model import ModelRun
 
-    config = SwanConfig(cgrid=cgrid, forcing=[wind], lockup=lockup)
+    config = SwanConfig(cgrid=cgrid, forcing=FORCING(wind=wind), lockup=lockup)
     model = ModelRun(
         run_id="test",
         period=dict(start="20230101T00", duration="12h", interval="1h"),
@@ -122,7 +122,7 @@ def test_forcing_and_inpgrid_coexist(cgrid, wind, lockup, tmpdir):
             )
         ]
     )
-    config = SwanConfig(cgrid=cgrid, inpgrid=inpgrid, forcing=[wind], lockup=lockup)
+    config = SwanConfig(cgrid=cgrid, inpgrid=inpgrid, forcing=FORCING(wind=wind), lockup=lockup)
     model = ModelRun(
         run_id="test",
         period=dict(start="20230101T00", duration="12h", interval="1h"),

--- a/tests/test_swan_config.py
+++ b/tests/test_swan_config.py
@@ -1,104 +1,137 @@
+"""Tests for SwanConfig.forcing field."""
+
+import pytest
+
 # Import test utilities
 from test_utils.logging import get_test_logger
 
-# Initialize logger
 logger = get_test_logger(__name__)
 
-
-"""Test swan_config class."""
-
-# import pytest
-# import logging
-# from rompy_swan.config import SwanConfig as SwanConfig
-# from rompy_swan.config import cgrid, inpgrid
-
-
-# logger = logging.getLogger(__name__)
+from rompy_swan.components.cgrid import REGULAR as CGRID_REGULAR
+from rompy_swan.components.group import LOCKUP
+from rompy_swan.components.inpgrid import ICE, WIND
+from rompy_swan.config import SwanConfig
+from rompy_swan.subcomponents.readgrid import GRIDREGULAR
+from rompy_swan.subcomponents.spectrum import SPECTRUM
 
 
-# @pytest.fixture(scope="module")
-# def cgrid_instance():
-#     inst = cgrid.REGULAR(
-#         mdc=36,
-#         flow=0.04,
-#         fhigh=0.4,
-#         xlenc=100.0,
-#         ylenc=100.0,
-#         mxc=10,
-#         myc=10,
-#     )
-#     yield inst
+@pytest.fixture(scope="module")
+def cgrid():
+    return CGRID_REGULAR(
+        spectrum=SPECTRUM(mdc=36, flow=0.04, fhigh=0.4),
+        grid=GRIDREGULAR(xp=0.0, yp=0.0, alp=0.0, xlen=1.0, ylen=1.0, mx=10, my=10),
+    )
 
 
-# @pytest.fixture(scope="module")
-# def inpgrid_instance():
-#     inst_wind = inpgrid.REGULAR(
-#         grid_type="WIND",
-#         xpinp=0.0,
-#         ypinp=0.0,
-#         alpinp=0.0,
-#         mxinp=10,
-#         myinp=10,
-#         dxinp=0.1,
-#         dyinp=0.1,
-#         excval=-999.0,
-#         nonstationary=inpgrid.NONSTATIONARY(
-#             tbeg="2023-01-01T00:00:00",
-#             delt="PT30M",
-#             tend="2023-02-01T00:00:00",
-#             deltfmt="hr",
-#         ),
-#         readinp=inpgrid.READINP(
-#             fname1="wind.txt",
-#         ),
-#     )
-#     inst_bottom = inst_wind.copy()
-#     inst_bottom.grid_type = "BOTTOM"
-#     inst_bottom.nonstationary = None
-#     inst_bottom.readinp.fname1 = "bottom.txt"
-#     yield [inst_bottom, inst_wind]
+@pytest.fixture(scope="module")
+def lockup():
+    return LOCKUP(compute=dict(model_type="stat"))
 
 
-# def _test_swan_config_from_objects(cgrid_instance, inpgrid_instance):
-#     sc = SwanConfig(
-#         cgrid=cgrid_instance,
-#         inpgrid=inpgrid_instance,
-#     )
-#     sc._write_cmd()
+@pytest.fixture(scope="module")
+def wind():
+    return WIND(vel=10.0, dir=270.0)
 
 
-# def _test_swan_config_from_dict():
-#     cgrid_dict = {
-#         "model_type": "regular",
-#         "mdc": 36,
-#         "flow": 0.04,
-#         "fhigh": 0.4,
-#         "xlenc": 100.0,
-#         "ylenc": 100.0,
-#         "mxc": 10,
-#         "myc": 10,
-#     }
-#     inpgrid_wind_dict = {
-#         "model_type": "regular",
-#         "grid_type": "wind",
-#         "xpinp": 0.0,
-#         "ypinp": 0.0,
-#         "alpinp": 0.0,
-#         "mxinp": 10,
-#         "myinp": 10,
-#         "dxinp": 0.1,
-#         "dyinp": 0.1,
-#         "excval": -999.0,
-#         "nonstationary": {
-#             "tbeg": "2023-01-01T00:00:00",
-#             "delt": "PT30M",
-#             "tend": "2023-02-01T00:00:00",
-#             "deltfmt": "hr",
-#         },
-#         "readinp": {"fname1": "wind.txt"},
-#     }
-#     sc = SwanConfig(
-#         cgrid=cgrid_dict,
-#         inpgrid=[inpgrid_wind_dict],
-#     )
-#     sc._write_cmd()
+@pytest.fixture(scope="module")
+def ice():
+    return ICE(aice=0.5, hice=1.5)
+
+
+def test_forcing_wind(cgrid, wind):
+    config = SwanConfig(cgrid=cgrid, forcing=[wind])
+    assert len(config.forcing) == 1
+    assert isinstance(config.forcing[0], WIND)
+    assert config.forcing[0].vel == 10.0
+    assert config.forcing[0].dir == 270.0
+
+
+def test_forcing_ice(cgrid, ice):
+    config = SwanConfig(cgrid=cgrid, forcing=[ice])
+    assert len(config.forcing) == 1
+    assert isinstance(config.forcing[0], ICE)
+    assert config.forcing[0].aice == 0.5
+    assert config.forcing[0].hice == 1.5
+
+
+def test_forcing_multiple(cgrid, wind, ice):
+    config = SwanConfig(cgrid=cgrid, forcing=[wind, ice])
+    assert len(config.forcing) == 2
+    assert isinstance(config.forcing[0], WIND)
+    assert isinstance(config.forcing[1], ICE)
+
+
+def test_forcing_from_dict(cgrid):
+    config = SwanConfig(
+        cgrid=cgrid,
+        forcing=[
+            {"model_type": "wind", "vel": 15.0, "dir": 90.0},
+            {"model_type": "ice", "aice": 0.3, "hice": 1.0},
+        ],
+    )
+    assert len(config.forcing) == 2
+    assert isinstance(config.forcing[0], WIND)
+    assert config.forcing[0].vel == 15.0
+    assert isinstance(config.forcing[1], ICE)
+
+
+def test_forcing_none_by_default(cgrid):
+    config = SwanConfig(cgrid=cgrid)
+    assert config.forcing is None
+
+
+def test_forcing_render_in_call(cgrid, wind, lockup, tmpdir):
+    """forcing items appear in the rendered INPUT file."""
+    from rompy.model import ModelRun
+
+    config = SwanConfig(cgrid=cgrid, forcing=[wind], lockup=lockup)
+    model = ModelRun(
+        run_id="test",
+        period=dict(start="20230101T00", duration="12h", interval="1h"),
+        output_dir=str(tmpdir),
+        config=config,
+    )
+    model.generate()
+
+    input_file = tmpdir.join("test", "INPUT")
+    content = input_file.read()
+    logger.info(content)
+    assert "WIND vel=10.0 dir=270.0" in content
+
+
+def test_forcing_and_inpgrid_coexist(cgrid, wind, lockup, tmpdir):
+    """forcing and inpgrid can be specified together."""
+    from rompy.model import ModelRun
+    from rompy_swan.components.group import INPGRIDS
+    from rompy_swan.components.inpgrid import READINP
+    from rompy_swan.components.inpgrid import REGULAR as INPGRID_REGULAR
+
+    inpgrid = INPGRIDS(
+        inpgrids=[
+            INPGRID_REGULAR(
+                grid_type="bottom",
+                xpinp=0.0,
+                ypinp=0.0,
+                alpinp=0.0,
+                mxinp=10,
+                myinp=10,
+                dxinp=0.1,
+                dyinp=0.1,
+                excval=-999.0,
+                readinp=READINP(fname1="bottom.txt"),
+            )
+        ]
+    )
+    config = SwanConfig(cgrid=cgrid, inpgrid=inpgrid, forcing=[wind], lockup=lockup)
+    model = ModelRun(
+        run_id="test",
+        period=dict(start="20230101T00", duration="12h", interval="1h"),
+        output_dir=str(tmpdir),
+        config=config,
+    )
+    model.generate()
+
+    input_file = tmpdir.join("test", "INPUT")
+    content = input_file.read()
+    assert "INPGRID BOTTOM" in content
+    assert "WIND vel=10.0 dir=270.0" in content

--- a/tests/test_swan_config.py
+++ b/tests/test_swan_config.py
@@ -1,4 +1,4 @@
-"""Tests for SwanConfig.forcing field."""
+"""Tests for SwanConfig validators."""
 
 import pytest
 
@@ -135,3 +135,80 @@ def test_forcing_and_inpgrid_coexist(cgrid, wind, lockup, tmpdir):
     content = input_file.read()
     assert "INPGRID BOTTOM" in content
     assert "WIND vel=10.0 dir=270.0" in content
+
+
+# ── SEGMENT IJ sentinel (-1) resolution ──────────────────────────────────────
+
+
+def test_segment_ij_sentinel_resolved(cgrid):
+    """BOUNDSPEC SEGMENT IJ: -1 is replaced by the cgrid max index (mx/my)."""
+    config = SwanConfig(
+        cgrid=cgrid,
+        boundary=dict(
+            model_type="boundspec",
+            location=dict(
+                model_type="segment",
+                points=dict(model_type="ij", i=[0, -1, -1], j=[-1, -1, 0]),
+            ),
+            data=dict(model_type="constantpar", hs=2.0, per=12.0, dir=270.0, dd=25.0),
+        ),
+    )
+    pts = config.boundary.location.points
+    mx = cgrid.grid.mx
+    my = cgrid.grid.my
+    assert -1 not in pts.i
+    assert -1 not in pts.j
+    assert pts.i == [0, mx, mx]
+    assert pts.j == [my, my, 0]
+
+
+def test_segment_ij_no_sentinel_unchanged(cgrid):
+    """BOUNDSPEC SEGMENT IJ without -1 is passed through unchanged."""
+    config = SwanConfig(
+        cgrid=cgrid,
+        boundary=dict(
+            model_type="boundspec",
+            location=dict(
+                model_type="segment",
+                points=dict(model_type="ij", i=[0, 10, 10], j=[10, 10, 0]),
+            ),
+            data=dict(model_type="constantpar", hs=2.0, per=12.0, dir=270.0, dd=25.0),
+        ),
+    )
+    pts = config.boundary.location.points
+    assert pts.i == [0, 10, 10]
+    assert pts.j == [10, 10, 0]
+
+
+def test_segment_ij_sentinel_renders_correctly(cgrid, lockup, tmpdir):
+    """Resolved SEGMENT IJ sentinel values appear correctly in the INPUT file."""
+    from rompy.model import ModelRun
+
+    config = SwanConfig(
+        cgrid=cgrid,
+        boundary=dict(
+            model_type="boundspec",
+            location=dict(
+                model_type="segment",
+                points=dict(model_type="ij", i=[0, -1, -1], j=[-1, -1, 0]),
+            ),
+            data=dict(model_type="constantpar", hs=2.0, per=12.0, dir=270.0, dd=25.0),
+        ),
+        lockup=lockup,
+    )
+    model = ModelRun(
+        run_id="test",
+        period=dict(start="20230101T00", duration="12h", interval="1h"),
+        output_dir=str(tmpdir),
+        config=config,
+    )
+    model.generate()
+
+    content = tmpdir.join("test", "INPUT").read()
+    mx = cgrid.grid.mx
+    my = cgrid.grid.my
+    assert f"i=0 j={my}" in content
+    assert f"i={mx} j={my}" in content
+    assert f"i={mx} j=0" in content
+    assert "i=-1" not in content
+    assert "j=-1" not in content


### PR DESCRIPTION
## Summary

- Adds a new `forcing` field to `SwanConfig` accepting a list of `WIND` and/or `ICE` components, allowing constant (non-grid) wind and ice inputs to be specified alongside `DataInterface`-based inputs in the `inpgrid` field — something that was previously impossible since both shared the same field
- Deprecates specifying `WIND`/`ICE` directly inside `INPGRIDS` (they remain supported but emit a `DeprecationWarning`)
- Adds a `{% if config.get("forcing") %}` block to the Jinja2 INPUT template so rendered forcing commands appear between the INPGRID and boundary sections
- Fixes two pydantic v2 issues that produced warnings: missing `return self` in `OutputInterface` and `LockupInterface` model validators, and bare `int` defaults / untyped union serialization for `IDLA` and discriminated union fields

## Changes

- `config.py` — new `forcing: Optional[list[FORCING_TYPE]]` field; rendered in `__call__`; `SerializeAsAny` on `INPGRID_TYPES` and `FORCING_TYPE`
- `components/group.py` — `SerializeAsAny` on `INPGRIDS.inpgrids`; deprecation warning when `WIND`/`ICE` are passed through `INPGRIDS`
- `interface.py` — add missing `return self` to `OutputInterface.time_interface` and `LockupInterface.time_interface`
- `subcomponents/readgrid.py` — change `READGRID.idla` default from bare `1` to `IDLA.ONE`
- `templates/.../INPUT` — new `forcing` block
- `tests/test_swan_config.py` — full test suite for the new `forcing` field (unit + integration tests)
- `tests/components/test_inpgrid.py` — tests for `WIND`/`ICE` rendering and deprecation warning

## Test plan

- [ ] `pytest tests/test_swan_config.py` — all forcing field tests pass
- [ ] `pytest tests/components/test_inpgrid.py` — WIND/ICE render and deprecation tests pass
- [ ] `pytest` — all 212 tests pass, no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)