### PR TITLE
relax filename size restriction for hotfiles

### DIFF
--- a/src/rompy_swan/subcomponents/boundary.py
+++ b/src/rompy_swan/subcomponents/boundary.py
@@ -604,7 +604,7 @@ class HOTSINGLE(BaseSubComponent):
     )
     fname: str = Field(
         description="Name of the file containing the initial wave field",
-        max_length=36,
+        max_length=80,
     )
     format: Literal["free", "unformatted"] = Field(
         default="free",
@@ -655,7 +655,7 @@ class HOTMULTIPLE(BaseSubComponent):
     )
     fname: str = Field(
         description="Name of the file containing the initial wave field",
-        max_length=36,
+        max_length=80,
     )
     format: Literal["free", "unformatted"] = Field(
         default="free",


### PR DESCRIPTION
The current limit for the `fname` option in the HOTSINGLE and HOTMULTIPLE subcomponents is 36 characters, which can be a bit restrictive for long hierarchical pathnames in filesystems, as in the example below. 

I make a suggestion here to increase that limit to 80, assuming there are no other drawbacks. I was initially working around that by copying/renaming the hotfile, but it may be handy to have the actual full path of the file in the declarative YAML configuration as a reference for programatically checking for hotfile existence, in workflows where you want to branch out to automatic spinup triggers based on hotfile absence. 

No particular reason for suggesting `max_length=80` as the new limit, just arbitrarily used Python pep8 as a reference. I'm also not sure if there are any other drawbacks to increasing this limit or perhaps not having a limit at all, so just putting this forward as a possible change. 

```yaml
config:
  model_type: swan
  startup:

  cgrid:
  
  inpgrid:

  boundary:
   
  initial:
    kind:
      model_type: hotsingle
      fname: /some/long/hierarchical/path/forecast/prod/model/cycle/model.hot
      format: free
```

I've tested it locally with SWAN 41.45, and it looks like the model accepts such long pathnames INPUT file in the `Boundary and Initial conditions` section (as below). The model ran without errors with that INPUT file.  

```bash
! Boundary and Initial conditions -------------------------------------------------------------------------------------------------------------------------------------------------

BOUNDNEST1 NEST 'model.bnd' CLOSED

INITIAL HOTSTART SINGLE fname=' /some/long/hierarchical/path/forecast/prod/model/cycle/model.hot' FREE
```

Cheers