### PR TITLE
Fix POINTS_FILE missing FILE keyword

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -33,6 +33,14 @@ are continually evolving. Contributions and feedback are welcome!
 Releases
 ********
 
+Unreleased
+__________
+
+Bug Fixes
+---------
+* The ``POINTS_FILE`` component now renders the mandatory ``FILE`` keyword, i.e. ``POINTS 'sname' FILE 'fname'``, so SWAN correctly reads the output locations from file. Reported by `@JOHN8736 <https://github.com/JOHN8736>`_ (`#17 <https://github.com/rom-py/rompy-swan/issues/17>`_).
+
+
 0.11.0 (2026-07-03)
 ____________________
 

--- a/src/rompy_swan/components/output.py
+++ b/src/rompy_swan/components/output.py
@@ -621,7 +621,7 @@ class POINTS_FILE(BaseLocation):
 
     def cmd(self) -> str:
         """Command file string for this component."""
-        repr = f"POINTS sname='{self.sname}' fname='{self.fname}'"
+        repr = f"POINTS sname='{self.sname}' FILE fname='{self.fname}'"
         return repr
 
 

--- a/tests/components/test_output.py
+++ b/tests/components/test_output.py
@@ -278,7 +278,7 @@ def test_points(points):
 
 def test_points_file():
     loc = POINTS_FILE(sname="outpts", fname="./output_points.nc")
-    assert loc.render() == "POINTS sname='outpts' fname='./output_points.nc'"
+    assert loc.render() == "POINTS sname='outpts' FILE fname='./output_points.nc'"
 
 
 def test_ngrid(ngrid):


### PR DESCRIPTION
Fixes #17.

## Problem

`POINTS_FILE` rendered the SWAN command without the mandatory `FILE` keyword:

```
POINTS sname='outpts' fname='buoys.txt'
```

The SWAN grammar for this command is:

```
POINTS 'sname' < [xp] [yp] > | FILE 'fname'
```

Without `FILE`, SWAN does not read the output locations from the file, which breaks any
`TABLE` / `SPECOUT` write component attached to that `sname`. The component's own docstring
already documents the correct form, so this was purely a slip in `cmd()`.

## Fix

Added the missing keyword in `POINTS_FILE.cmd()`, which now renders:

```
POINTS sname='outpts' FILE fname='buoys.txt'
```

The existing test had encoded the buggy string and was updated accordingly.

The other file-taking commands (`BRAGG_FILE`, `NGRID_UNSTRUCTURED`, `CONSTANTFILE`,
`VARIABLEFILE`, `HOTFILE`, `BLOCK` / `SPECOUT` / `NESTOUT`) were checked and do not have
the same omission. `TABLE` itself was fine — it only appeared broken in the report because
the malformed `POINTS` line meant `sname='outpts'` was never defined.

## Testing

Full suite passes: 204 passed, 1 skipped.

Thanks to @JOHN8736 for the clear report.
